### PR TITLE
[SFT-61]: The Events CP index shows both an Element and Title column

### DIFF
--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -1448,6 +1448,7 @@ class Event extends Element implements \JsonSerializable
     protected static function defineSortOptions(): array
     {
         return [
+            'title' => Calendar::t('Title'),
             'name' => Calendar::t('Calendar'),
             'startDate' => Calendar::t('Start Date'),
             'endDate' => Calendar::t('End Date'),

--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -1426,7 +1426,6 @@ class Event extends Element implements \JsonSerializable
     protected static function defineTableAttributes(): array
     {
         $attributes = [
-            'title' => ['label' => Calendar::t('Title')],
             'slug' => ['label' => Calendar::t('Slug')],
             'calendar' => ['label' => Calendar::t('Calendar')],
             'startDateLocalized' => ['label' => Calendar::t('Start Date')],
@@ -1449,7 +1448,6 @@ class Event extends Element implements \JsonSerializable
     protected static function defineSortOptions(): array
     {
         return [
-            'title' => Calendar::t('Title'),
             'name' => Calendar::t('Calendar'),
             'startDate' => Calendar::t('Start Date'),
             'endDate' => Calendar::t('End Date'),
@@ -1470,7 +1468,6 @@ class Event extends Element implements \JsonSerializable
     protected static function defineDefaultTableAttributes(string $source): array
     {
         return [
-            'title',
             'calendar',
             'startDate',
             'endDate',


### PR DESCRIPTION
Removed title as a table attribute and sort option within the CP Events index template

<img width="555" alt="SCR-20221125-nrb" src="https://user-images.githubusercontent.com/580403/204030762-e1259e17-d3aa-467b-afe1-a61b58848a52.png">
<img width="1037" alt="SCR-20221125-nr6-2" src="https://user-images.githubusercontent.com/580403/204030768-79c14103-334d-4e2f-92d6-50323415c60c.png">
