### PR TITLE
[SFT-185 + SFT-186]: Fixed Craft element editor modal for Calendar Event and Event Title Translations

### DIFF
--- a/packages/plugin/src/FieldTypes/EventFieldType.php
+++ b/packages/plugin/src/FieldTypes/EventFieldType.php
@@ -79,21 +79,6 @@ class EventFieldType extends BaseRelationField
         return $query;
     }
 
-    public static function supportedTranslationMethods(): array
-    {
-        return [
-            self::TRANSLATION_METHOD_SITE,
-            self::TRANSLATION_METHOD_SITE_GROUP,
-            self::TRANSLATION_METHOD_LANGUAGE,
-            self::TRANSLATION_METHOD_CUSTOM,
-        ];
-    }
-
-    public function getIsTranslatable(ElementInterface $element = null): bool
-    {
-        return true;
-    }
-
     public static function elementType(): string
     {
         return Event::class;

--- a/packages/plugin/src/Services/EventsService.php
+++ b/packages/plugin/src/Services/EventsService.php
@@ -208,7 +208,7 @@ class EventsService extends Component
             $transaction = \Craft::$app->db->beginTransaction();
 
             try {
-                $isSaved = \Craft::$app->elements->saveElement($event, $validateContent, $isNewEvent);
+                $isSaved = \Craft::$app->elements->saveElement($event, $validateContent);
                 if (!$isSaved) {
                     return false;
                 }

--- a/packages/plugin/src/templates/events/_edit.html
+++ b/packages/plugin/src/templates/events/_edit.html
@@ -100,13 +100,13 @@
     {% if event.id %}<input type="hidden" name="eventId" value="{{ event.id }}">{% endif %}
     <input type="hidden" name="{{ name ~ "[calendarId]" }}" value="{{ event.calendarId }}">
 
-    {% include "calendar/events/_event_editor" %}
-
     {% if form %}
-        <div id="fields">
+        <div id="fields" style="margin-bottom: 24px;">
             {{ form.render()|raw }}
         </div>
     {% endif %}
+
+    {% include "calendar/events/_event_editor" %}
 
 {% endblock %}
 

--- a/packages/plugin/src/templates/events/_event_editor.html
+++ b/packages/plugin/src/templates/events/_event_editor.html
@@ -1,19 +1,5 @@
 {% import "_includes/forms" as forms %}
 
-{% if event.calendar.hasTitleField %}
-  {{ forms.textField({
-    label: event.calendar.titleLabel|t('calendar'),
-    id: 'title',
-    name: 'title',
-    siteId: event.siteId,
-    value: event.title,
-    errors: event.getErrors('title'),
-    first: true,
-    autofocus: true,
-    required: true
-  }) }}
-{% endif %}
-
 <script>
   var existingEventData = {{ eventData|json_encode|raw }};
   var eventConfig = {{ eventConfig|json_encode|raw }};


### PR DESCRIPTION
- [SFT-185] When attempting to edit a Calendar event through the Craft element editor modal, it fails.
- [SFT-185] When a calendar has NOT TRANSLATABLE set for the title, it still translates it per site.


[SFT-185]: https://solspace.atlassian.net/browse/SFT-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFT-185]: https://solspace.atlassian.net/browse/SFT-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ