### PR TITLE
[SFT-193]: Column 'titleTranslationMethod' cannot be null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "post-update-cmd": "cghooks update"
   },
   "extra": {
-    "schemaVersion": "4.0.1",
+    "schemaVersion": "4.0.2",
     "handle": "calendar",
     "class": "Solspace\\Calendar\\Calendar",
     "name": "Calendar",

--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -482,8 +482,12 @@ class Event extends Element implements \JsonSerializable
             ]);
         }
 
-        foreach ($this->getCalendar()->getFieldLayout()->getTabs() as $tab) {
-            $layoutElements = array_merge($layoutElements, $tab->getElements());
+        $fieldLayout = $this->getCalendar()->getFieldLayout();
+
+        if ($fieldLayout) {
+            foreach ($fieldLayout->getTabs() as $tab) {
+                $layoutElements = array_merge($layoutElements, $tab->getElements());
+            }
         }
 
         $fieldLayout = new FieldLayout();

--- a/packages/plugin/src/migrations/Install.php
+++ b/packages/plugin/src/migrations/Install.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Calendar\migrations;
 
+use craft\base\Field;
 use Solspace\Commons\Migrations\ForeignKey;
 use Solspace\Commons\Migrations\StreamlinedInstallMigration;
 use Solspace\Commons\Migrations\Table;
@@ -24,6 +25,8 @@ class Install extends StreamlinedInstallMigration
                 ->addField('titleFormat', $this->string())
                 ->addField('titleLabel', $this->string()->defaultValue('Title'))
                 ->addField('hasTitleField', $this->boolean()->notNull()->defaultValue(true))
+                ->addField('titleTranslationMethod', $this->string()->notNull()->defaultValue(Field::TRANSLATION_METHOD_SITE))
+                ->addField('titleTranslationKeyFormat', $this->text())
                 ->addField('descriptionFieldHandle', $this->string())
                 ->addField('locationFieldHandle', $this->string())
                 ->addField('icsHash', $this->string())

--- a/packages/plugin/src/migrations/m230126_190648_AddMissingCalendarTitleTranslationMethodColumn.php
+++ b/packages/plugin/src/migrations/m230126_190648_AddMissingCalendarTitleTranslationMethodColumn.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Solspace\Calendar\migrations;
+
+use craft\base\Field;
+use craft\db\Migration;
+
+/**
+ * m230126_190648_AddMissingCalendarTitleTranslationMethodColumn migration.
+ */
+class m230126_190648_AddMissingCalendarTitleTranslationMethodColumn extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $table = $this->getDb()->getTableSchema('{{%calendar_calendars}}');
+
+        if (!$table->getColumn('titleTranslationMethod')) {
+            $this->addColumn('{{%calendar_calendars}}', 'titleTranslationMethod', $this->string()->notNull()->defaultValue(Field::TRANSLATION_METHOD_SITE)->after('hasTitleField'));
+        }
+
+        if (!$table->getColumn('titleTranslationKeyFormat')) {
+            $this->addColumn('{{%calendar_calendars}}', 'titleTranslationKeyFormat', $this->text()->after('titleTranslationMethod'));
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m230126_190648_AddMissingCalendarTitleTranslationMethodColumn cannot be reverted.\n";
+
+        return false;
+    }
+}

--- a/packages/plugin/src/templates/calendars/_edit.html
+++ b/packages/plugin/src/templates/calendars/_edit.html
@@ -214,6 +214,9 @@
                     errors: calendar.getErrors('titleTranslationKeyFormat')
                 }) }}
             </div>
+        {% else %}
+            <input type="hidden" name="titleTranslationMethod" value="none">
+            <input type="hidden" name="titleTranslationKeyFormat" value="">
         {% endif %}
 
         {{ forms.textField({


### PR DESCRIPTION
[#196]

- Fixed `titleTranslationMethod` cannot be null error when only 1 site (e.g. none multi-site)
- Fixed bug where Calendar had no field layouts
- Correctly adding `titleTranslationMethod` and `titleTranslationKeyFormat` fields during a fresh install or update