### PR TITLE
Craft 4 - Fixed events not loading with PostgreSQL #214

### DIFF
--- a/packages/plugin/src/templates/view/calendar.html
+++ b/packages/plugin/src/templates/view/calendar.html
@@ -127,9 +127,6 @@
                             {{ "Calendars"|t('calendar') }}
                         </span>
                     </li>
-                    <input type="hidden"
-                           name="calendars[]"
-                           value="">
                     {% for id, calendar in craft.calendar.calendars %}
                         <li class="item">
                             <input type="checkbox"


### PR DESCRIPTION
Fixes bug reported in https://github.com/solspace/craft-calendar/issues/214

Empty calendar id value was introduced by https://github.com/solspace/craft-calendar/pull/170