### PR TITLE
[SFT-288] - Disabled events disappear from events list #220

### DIFF
--- a/packages/plugin/src/Services/EventsService.php
+++ b/packages/plugin/src/Services/EventsService.php
@@ -138,7 +138,6 @@ class EventsService extends Component
                 'and',
                 'events.[[freq]] IS NULL',
                 'elements.[[dateDeleted]] IS NULL',
-                'elements.[[enabled]] = TRUE',
                 ['in', 'events.[[id]]', $ids],
                 ['in', 'elements_sites.[[siteId]]', $siteIds],
             ])
@@ -187,7 +186,6 @@ class EventsService extends Component
                 'and',
                 'events.[[freq]] IS NOT NULL',
                 'elements.[[dateDeleted]] IS NULL',
-                'elements.[[enabled]] = TRUE',
                 ['in', 'events.[[id]]', $ids],
                 ['in', 'elements_sites.[[siteId]]', $siteIds],
             ])

--- a/packages/plugin/src/templates/events/_edit.html
+++ b/packages/plugin/src/templates/events/_edit.html
@@ -275,6 +275,7 @@
     {% endjs %}
 {% endif %}
 
+{% if showSites %}
 {% js %}
     const $globalLightSwitch = $('#event-sites').find('#enabled.lightswitch');
     const $siteLightSwitches = $('#event-sites').find('.lightswitch:not("#enabled")');
@@ -325,3 +326,4 @@
         updateGlobalStatus();
     });
 {% endjs %}
+{% endif %}


### PR DESCRIPTION
- Updated query so all statuses are included.
- Then fixed event edit template to show correct status when only 1 site.
