### PR TITLE
Check user permissions only for enabled sites

### DIFF
--- a/packages/plugin/src/Controllers/EventsController.php
+++ b/packages/plugin/src/Controllers/EventsController.php
@@ -679,6 +679,10 @@ class EventsController extends BaseController
         if (is_array($enabledForSite)) {
             // Make sure they are allowed to edit all of the posted site IDs
             $editableSiteIds = \Craft::$app->getSites()->getEditableSiteIds();
+
+            // Filter out any sites which are not enabled for the entry
+            $enabledForSite = array_filter($enabledForSite);
+
             if (array_diff(array_keys($enabledForSite), $editableSiteIds)) {
                 throw new ForbiddenHttpException('User not permitted to edit the statuses for all the submitted site IDs');
             }


### PR DESCRIPTION
This PR removes empty strings (aka websites with disabled entry status) when checking if a user has permission to edit those sites.

Fixes: https://github.com/solspace/craft-calendar/issues/222