### PR TITLE
[SFT-737] - Changing a calendar's settings shifts all associated recurring event start/end dates to be the same as the End repeat date

### DIFF
--- a/packages/plugin/src/Controllers/EventsController.php
+++ b/packages/plugin/src/Controllers/EventsController.php
@@ -220,11 +220,11 @@ class EventsController extends BaseController
         }
 
         $enabledForSite = $this->enabledForSiteValue();
-        if (is_array($enabledForSite)) {
+        if (\is_array($enabledForSite)) {
             // Set the global status to true if it's enabled for *any* sites, or if already enabled.
-            $event->enabled = in_array(true, $enabledForSite, false) || $event->enabled;
+            $event->enabled = \in_array(true, $enabledForSite, false) || $event->enabled;
         } else {
-            $event->enabled = (bool)$this->request->getBodyParam('enabled', $event->enabled);
+            $event->enabled = (bool) $this->request->getBodyParam('enabled', $event->enabled);
         }
         $event->setEnabledForSite($enabledForSite ?? $event->getEnabledForSite());
         $event->title = \Craft::$app->request->post('title', $event->title);
@@ -383,6 +383,30 @@ class EventsController extends BaseController
         }
 
         return $this->showEvent($event);
+    }
+
+    /**
+     * Returns the posted `enabledForSite` value, taking the user’s permissions into account.
+     *
+     * @throws ForbiddenHttpException
+     *
+     * @return null|bool|bool[]
+     *
+     * @since 3.4.0
+     */
+    protected function enabledForSiteValue(): array|bool|null
+    {
+        $enabledForSite = $this->request->getBodyParam('enabledForSite');
+        if (\is_array($enabledForSite)) {
+            // Make sure they are allowed to edit all of the posted site IDs
+            $editableSiteIds = \Craft::$app->getSites()->getEditableSiteIds();
+
+            if (array_diff(array_keys($enabledForSite), $editableSiteIds)) {
+                throw new ForbiddenHttpException('User not permitted to edit the statuses for all the submitted site IDs');
+            }
+        }
+
+        return $enabledForSite;
     }
 
     /**
@@ -564,11 +588,11 @@ class EventsController extends BaseController
 
         $event->slug = $request->getBodyParam('slug', $event->slug);
         $enabledForSite = $this->enabledForSiteValue();
-        if (is_array($enabledForSite)) {
+        if (\is_array($enabledForSite)) {
             // Set the global status to true if it's enabled for *any* sites, or if already enabled.
-            $event->enabled = in_array(true, $enabledForSite, false) || $event->enabled;
+            $event->enabled = \in_array(true, $enabledForSite, false) || $event->enabled;
         } else {
-            $event->enabled = (bool)$this->request->getBodyParam('enabled', $event->enabled);
+            $event->enabled = (bool) $this->request->getBodyParam('enabled', $event->enabled);
         }
         $event->setEnabledForSite($enabledForSite ?? $event->getEnabledForSite());
         $event->title = $request->getBodyParam('title', $event->title);
@@ -664,26 +688,5 @@ class EventsController extends BaseController
         if (!$hasPermission) {
             CalendarPermissionHelper::requirePermission('trigger-calendar-event-access-denied');
         }
-    }
-
-    /**
-     * Returns the posted `enabledForSite` value, taking the user’s permissions into account.
-     *
-     * @return bool|bool[]|null
-     * @throws ForbiddenHttpException
-     * @since 3.4.0
-     */
-    protected function enabledForSiteValue(): array|bool|null
-    {
-        $enabledForSite = $this->request->getBodyParam('enabledForSite');
-        if (is_array($enabledForSite)) {
-            // Make sure they are allowed to edit all of the posted site IDs
-            $editableSiteIds = \Craft::$app->getSites()->getEditableSiteIds();
-
-            if (array_diff(array_keys($enabledForSite), $editableSiteIds)) {
-                throw new ForbiddenHttpException('User not permitted to edit the statuses for all the submitted site IDs');
-            }
-        }
-        return $enabledForSite;
     }
 }

--- a/packages/plugin/src/Controllers/ViewController.php
+++ b/packages/plugin/src/Controllers/ViewController.php
@@ -85,7 +85,7 @@ class ViewController extends BaseController
         $siteMap = [];
         if (\Craft::$app->getIsMultiSite()) {
             foreach (\Craft::$app->sites->getAllSites() as $site) {
-                if (!$user->can("editSite:".$site->uid)) {
+                if (!$user->can('editSite:'.$site->uid)) {
                     continue;
                 }
 

--- a/packages/plugin/src/Elements/Db/EventQuery.php
+++ b/packages/plugin/src/Elements/Db/EventQuery.php
@@ -491,16 +491,13 @@ class EventQuery extends ElementQuery
         if (null === $this->events || self::$lastCachedConfigStateHash !== $configHash) {
             $limit = $this->limit;
             $offset = $this->offset;
-            $indexBy = $this->indexBy;
             $this->limit = null;
             $this->offset = null;
-            $this->indexBy = null;
 
             $ids = parent::ids($db);
 
             $this->limit = $limit;
             $this->offset = $offset;
-            $this->indexBy = $indexBy;
 
             if (empty($ids)) {
                 return [];
@@ -929,7 +926,7 @@ class EventQuery extends ElementQuery
      */
     private function cacheSingleEvents($foundIds)
     {
-        if (!is_array($this->siteId)) {
+        if (!\is_array($this->siteId)) {
             $this->siteId = [$this->siteId];
         }
 
@@ -948,7 +945,7 @@ class EventQuery extends ElementQuery
      */
     private function cacheRecurringEvents(array $foundIds)
     {
-        if (!is_array($this->siteId)) {
+        if (!\is_array($this->siteId)) {
             $this->siteId = [$this->siteId];
         }
 
@@ -1185,10 +1182,6 @@ class EventQuery extends ElementQuery
 
     /**
      * Adds event ID and occurrence date to the cache.
-     *
-     * @param int $eventId
-     * @param Carbon $date
-     * @param int $siteId
      */
     private function cacheEvent(int $eventId, Carbon $date, int $siteId)
     {

--- a/packages/plugin/src/Services/EventsService.php
+++ b/packages/plugin/src/Services/EventsService.php
@@ -13,6 +13,8 @@ use craft\events\DeleteElementEvent as CraftDeleteElementEvent;
 use craft\events\SiteEvent;
 use craft\helpers\ArrayHelper;
 use craft\helpers\ElementHelper;
+use craft\records\Element as ElementRecord;
+use craft\records\Element_SiteSettings as ElementSiteSettingsRecord;
 use Solspace\Calendar\Calendar;
 use Solspace\Calendar\Elements\Db\EventQuery;
 use Solspace\Calendar\Elements\Event;
@@ -22,8 +24,6 @@ use Solspace\Calendar\Library\CalendarPermissionHelper;
 use Solspace\Calendar\Library\DateHelper;
 use Solspace\Calendar\Models\SelectDateModel;
 use Solspace\Calendar\Records\CalendarRecord;
-use craft\records\Element as ElementRecord;
-use craft\records\Element_SiteSettings as ElementSiteSettingsRecord;
 use yii\web\HttpException;
 
 class EventsService extends Component
@@ -113,11 +113,6 @@ class EventsService extends Component
         return Event::buildQuery($criteria);
     }
 
-    /**
-     * @param array|null $ids
-     * @param array|null $siteIds
-     * @return array
-     */
     public function getSingleEventMetadata(array $ids = null, array $siteIds = null): array
     {
         $ids = array_unique($ids);
@@ -161,11 +156,6 @@ class EventsService extends Component
         return $query->all();
     }
 
-    /**
-     * @param array|null $ids
-     * @param array|null $siteIds
-     * @return array
-     */
     public function getRecurringEventMetadata(array $ids = null, array $siteIds = null): array
     {
         $ids = array_unique($ids);

--- a/packages/plugin/src/Variables/CalendarVariable.php
+++ b/packages/plugin/src/Variables/CalendarVariable.php
@@ -14,9 +14,9 @@ use Solspace\Calendar\Library\Events\EventWeek;
 use Solspace\Calendar\Library\Export\ExportCalendarToIcs;
 use Solspace\Calendar\Library\RecurrenceHelper;
 use Solspace\Calendar\Models\CalendarModel;
+use Solspace\Calendar\Services\CalendarSitesService;
 use Solspace\Calendar\Services\FormatsService;
 use Solspace\Calendar\Services\SettingsService;
-use Solspace\Calendar\Services\CalendarSitesService;
 
 class CalendarVariable
 {


### PR DESCRIPTION
Removed changes for https://github.com/solspace/craft-calendar/issues/136 from here https://github.com/solspace/craft-calendar/commit/fd6d4aa65ee8bead2fe9abc7fa407d8e2bd69289#diff-7c9985f89ed82fa18d09bf2bd55c404b9cc430294101ec56c3b5d8d2199cc2d1R490-R499 

I cannot replicate original issues described in #136 in latest version (v4.0.9)

COMMITS INCLUDE LINTING FIXES