### PR TITLE
fix(SFT-978): Added select date localized and exception date localized

### DIFF
--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -540,6 +540,19 @@ class Event extends Element implements \JsonSerializable
         return $this->exceptions;
     }
 
+    /**
+     * @return ExceptionModel[]
+     */
+    public function getExceptionsLocalized(): array
+    {
+        $exceptionsLocalized = $this->getExceptions();
+        foreach ($exceptionsLocalized as $exceptionLocalized) {
+            $exceptionLocalized->date = new Carbon($exceptionLocalized->date->toDateTimeString());
+        }
+
+        return $exceptionsLocalized;
+    }
+
     public function setExceptions(array $exceptions): self
     {
         $this->exceptions = [];
@@ -653,6 +666,18 @@ class Event extends Element implements \JsonSerializable
         $dates = [];
         foreach ($models as $model) {
             $dates[] = $model->date;
+        }
+
+        return $dates;
+    }
+
+    public function getSelectDatesAsDatesLocalized(?\DateTime $rangeStart = null, ?\DateTime $rangeEnd = null): array
+    {
+        $models = $this->getSelectDates($rangeStart, $rangeEnd);
+
+        $dates = [];
+        foreach ($models as $model) {
+            $dates[] = new Carbon($model->date->toDateTimeString());
         }
 
         return $dates;


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-calendar/issues/263

```
{% for selectDate in event.selectDatesAsDates %}
   {{ selectDate.format('l, F j, Y') }}
{% endfor %}

{% for selectDate in event.selectDatesAsDatesLocalized %}
   {{ selectDate|date('l, F j, Y') }}
{% endfor %}

{% for exception in event.exceptions %}
   {{ exception.date.format('l, F j, Y') }}
{% endfor %}

{% for exception in event.exceptionsLocalized %}
   {{ exception.date|date('l, F j, Y') }}
{% endfor %}
```