### PR TITLE
fix(SFT-1029): Fixed Typed static property must not be accessed before initialization

### DIFF
--- a/packages/plugin/src/Bundles/GraphQL/Types/AbstractObjectType.php
+++ b/packages/plugin/src/Bundles/GraphQL/Types/AbstractObjectType.php
@@ -10,7 +10,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 abstract class AbstractObjectType extends ObjectType
 {
-    private static PropertyAccessor $propertyAccess;
+    private static ?PropertyAccessor $propertyAccess = null;
 
     public function __construct(array $config)
     {


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-calendar/issues/272