### PR TITLE
fix(SFT-1021): Fixed reoccurring events not returning when using batch calls

### DIFF
--- a/packages/plugin/src/Elements/Db/EventQuery.php
+++ b/packages/plugin/src/Elements/Db/EventQuery.php
@@ -436,6 +436,11 @@ class EventQuery extends ElementQuery
         return $this->events;
     }
 
+    public function batch($batchSize = null, $db = null): array
+    {
+        return array_chunk($this->all($db), $batchSize);
+    }
+
     public function nth(int $n, ?Connection $db = null): null|array|Model
     {
         $this->all($db);


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-calendar/issues/255

Takes `all` events and splits them into chunks based on batch size