### PR TITLE
fix: extra check before running main body of listener method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Solspace Calendar Changelog
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where installation of Craft CMS would break if the Calendar plugin was enabled in Project Config [#297]
+
 ## 5.0.5 - 2024-06-07
 
 ### Changed

--- a/packages/plugin/src/Services/CalendarsService.php
+++ b/packages/plugin/src/Services/CalendarsService.php
@@ -453,6 +453,13 @@ class CalendarsService extends Component
 
     public function addSiteHandler(SiteEvent $event): bool
     {
+        if (false === \Craft::$app->getPlugins()->isPluginEnabled('calendar')) {
+            // This method can be called as a listener during installation,
+            // when the plugin specific tables are not created yet.
+            // @see https://github.com/solspace/craft-calendar/issues/297#issuecomment-2186480291
+            return true;
+        }
+
         if (!$event->isNew) {
             return true;
         }

--- a/packages/plugin/src/Services/EventsService.php
+++ b/packages/plugin/src/Services/EventsService.php
@@ -387,6 +387,13 @@ class EventsService extends Component
      */
     public function addSiteHandler(SiteEvent $event): bool
     {
+        if (false === \Craft::$app->getPlugins()->isPluginEnabled('calendar')) {
+            // This method can be called as a listener during installation,
+            // when the plugin specific tables are not created yet.
+            // @see https://github.com/solspace/craft-calendar/issues/297#issuecomment-2186480291
+            return true;
+        }
+
         if (!$event->isNew) {
             return true;
         }


### PR DESCRIPTION
Extra check prevents the method from running during installation of Craft CMS. This is necessary because during installation the plugin specific custom tables don't exist yet, and thus the listener throws an error.

 Refers to issue #297