### PR TITLE
fix(SFT-1343) importing calendar events with empty rrules using feedme plugin

### DIFF
--- a/packages/plugin/src/Bundles/ExternalPluginSupport/FeedMe/CalendarIntegration.php
+++ b/packages/plugin/src/Bundles/ExternalPluginSupport/FeedMe/CalendarIntegration.php
@@ -37,9 +37,9 @@ if (class_exists('craft\feedme\base\Element')) {
 
         public $element;
 
-        private array $rruleInfo = [];
+        private ?array $rruleInfo = [];
 
-        private array $selectDates = [];
+        private ?array $selectDates = [];
 
         public function getGroupsTemplate(): string
         {


### PR DESCRIPTION
**Fixes** 

https://github.com/solspace/craft-calendar/issues/304

**REQUIRES THIS PR TO BE MERGED FIRST**

https://github.com/solspace/craft-calendar/pull/307