### PR TITLE
Add support for `Elements::EVENT_REGISTER_ELEMENT_TYPES`

### DIFF
--- a/packages/plugin/src/Calendar.php
+++ b/packages/plugin/src/Calendar.php
@@ -130,6 +130,7 @@ class Calendar extends Plugin
         $this->initTemplateVariables();
         $this->initWidgets();
         $this->initFieldTypes();
+        $this->initElementTypes();
         $this->initEventListeners();
         $this->initPermissions();
         $this->initBundles();
@@ -359,6 +360,17 @@ class Calendar extends Plugin
             function (RegisterComponentTypesEvent $event) {
                 $event->types[] = EventFieldType::class;
                 $event->types[] = CalendarFieldType::class;
+            }
+        );
+    }
+
+    private function initElementTypes(): void
+    {
+        Event::on(
+            Elements::class,
+            Elements::EVENT_REGISTER_ELEMENT_TYPES,
+            function (RegisterComponentTypesEvent $event) {
+                $event->types[] = \Solspace\Calendar\Elements\Event::class;
             }
         );
     }


### PR DESCRIPTION
Allows the Event element to be registered properly with Craft. For reference https://github.com/verbb/navigation/discussions/406#discussioncomment-10868600