### PR TITLE
fix(SFT-1408): removed author attribute from sort options list for CP events index

### DIFF
--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -1470,7 +1470,7 @@ class Event extends Element implements \JsonSerializable
         // Slug
         $fields[] = $this->slugFieldHtml($static);
 
-        // Author
+        // Author - Hide Author from Craft Solo
         if (\Craft::Solo !== \Craft::$app->getEdition()) {
             $fields[] = (function () use ($static) {
                 $author = $this->getAuthor();
@@ -1597,6 +1597,11 @@ class Event extends Element implements \JsonSerializable
         $names[] = 'authorId';
         $names[] = 'author';
 
+        // Hide Author from Craft Solo
+        if (\Craft::Solo === \Craft::$app->getEdition()) {
+            unset($names['authorId'], $names['author']);
+        }
+
         return $names;
     }
 
@@ -1606,25 +1611,17 @@ class Event extends Element implements \JsonSerializable
         $names[] = 'authorId';
         $names[] = 'author';
 
+        // Hide Author from Craft Solo
+        if (\Craft::Solo === \Craft::$app->getEdition()) {
+            unset($names['authorId'], $names['author']);
+        }
+
         return $names;
     }
 
     protected static function prepElementQueryForTableAttribute(ElementQueryInterface $elementQuery, string $attribute): void
     {
-        switch ($attribute) {
-            case 'authorId':
-                $elementQuery->andWith(['authorId', ['status' => null]]);
-
-                break;
-
-            case 'author':
-                $elementQuery->andWith(['author', ['status' => null]]);
-
-                break;
-
-            default:
-                parent::prepElementQueryForTableAttribute($elementQuery, $attribute);
-        }
+        parent::prepElementQueryForTableAttribute($elementQuery, $attribute);
     }
 
     protected static function defineSources(?string $context = null): array
@@ -1681,9 +1678,8 @@ class Event extends Element implements \JsonSerializable
 
     protected static function defineSortOptions(): array
     {
-        return [
+        $attributes = [
             'authorId' => Calendar::t('Author ID'),
-            'author' => Calendar::t('Author'),
             'title' => Calendar::t('Title'),
             'name' => Calendar::t('Calendar'),
             'startDate' => Calendar::t('Start Date'),
@@ -1691,18 +1687,37 @@ class Event extends Element implements \JsonSerializable
             'allDay' => Calendar::t('All Day'),
             'postDate' => Calendar::t('Post Date'),
         ];
+
+        // Hide Author from Craft Solo
+        if (\Craft::Solo === \Craft::$app->getEdition()) {
+            unset($attributes['authorId']);
+        }
+
+        return $attributes;
     }
 
     protected static function defineSearchableAttributes(): array
     {
-        return ['authorId', 'author', 'id', 'title', 'startDate', 'endDate'];
+        $attributes = [
+            'authorId',
+            'author',
+            'id',
+            'title',
+            'startDate',
+            'endDate',
+        ];
+
+        // Hide Author from Craft Solo
+        if (\Craft::Solo === \Craft::$app->getEdition()) {
+            unset($attributes['authorId'], $attributes['author']);
+        }
+
+        return $attributes;
     }
 
     protected static function defineDefaultTableAttributes(string $source): array
     {
         return [
-            'authorId',
-            'author',
             'calendar',
             'startDate',
             'endDate',

--- a/packages/plugin/src/Elements/conditions/AuthorConditionRule.php
+++ b/packages/plugin/src/Elements/conditions/AuthorConditionRule.php
@@ -19,7 +19,9 @@ class AuthorConditionRule extends BaseElementSelectConditionRule implements Elem
 
     public function getExclusiveQueryParams(): array
     {
-        return ['author', 'authorId'];
+        return [
+            'authorId',
+        ];
     }
 
     public function modifyQuery(ElementQueryInterface $query): void

--- a/packages/plugin/src/Elements/conditions/EventCondition.php
+++ b/packages/plugin/src/Elements/conditions/EventCondition.php
@@ -9,7 +9,14 @@ class EventCondition extends ElementCondition
     // Craft 4
     protected function conditionRuleTypes(): array
     {
-        return array_merge(parent::conditionRuleTypes(), [
+        $conditions = parent::conditionRuleTypes();
+
+        // Hide Author Conditions from Craft Solo
+        if (\Craft::Solo === \Craft::$app->getEdition()) {
+            return $conditions;
+        }
+
+        return array_merge($conditions, [
             AuthorConditionRule::class,
         ]);
     }
@@ -17,7 +24,14 @@ class EventCondition extends ElementCondition
     // Craft 5
     protected function selectableConditionRules(): array
     {
-        return array_merge(parent::selectableConditionRules(), [
+        $conditions = parent::selectableConditionRules();
+
+        // Hide Author Conditions from Craft Solo
+        if (\Craft::Solo === \Craft::$app->getEdition()) {
+            return $conditions;
+        }
+
+        return array_merge($conditions, [
             AuthorConditionRule::class,
         ]);
     }


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-calendar/issues/335

`author` attribute adding by mistake to sort options list.