### PR TITLE
Delete orphaned event field layouts during garbage collection

### DIFF
--- a/packages/plugin/src/Calendar.php
+++ b/packages/plugin/src/Calendar.php
@@ -12,6 +12,7 @@ use craft\helpers\StringHelper;
 use craft\services\Dashboard;
 use craft\services\Elements;
 use craft\services\Fields;
+use craft\services\Gc;
 use craft\services\Sites;
 use craft\services\UserPermissions;
 use craft\web\twig\variables\CraftVariable;
@@ -156,6 +157,17 @@ class Calendar extends Plugin
             && 'calendar' === \Craft::$app->request->getSegment(1)
         ) {
             \Craft::$app->view->registerAssetBundle(MainAssetBundle::class);
+        }
+
+        if (method_exists(Gc::class, 'deleteOrphanedFieldLayouts')) {
+            Event::on(Gc::class, Gc::EVENT_RUN, function(Event $event) {
+                /** @var Gc $gc */
+                $gc = $event->sender;
+                $gc->deleteOrphanedFieldLayouts(
+                    \Solspace\Calendar\Elements\Event::class,
+                    'calendar_calendars',
+                );
+            });
         }
     }
 


### PR DESCRIPTION
Adds support for `craft\servicse\Gc::deleteOrphanedFieldLayouts()` [coming](https://github.com/craftcms/cms/commit/1e1f01f7f7ef8623df4c22a0cd148b548122e04) in Craft 4.13 and 5.5, which will fix issues like https://github.com/craftcms/cms/issues/16032.