### PR TITLE
fix(SFT-1655): use rangeStart + 6 months when rangeEnd is null in getOccurrences for an infinite event

### DIFF
--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -1142,7 +1142,7 @@ class Event extends Element implements \JsonSerializable
 
             $rangeEnd = $occurrencesConfig->getRangeEnd();
             if (null === $rangeEnd) {
-                $rangeEnd = $this->isInfinite() ? new \DateTime('+6 months') : $this->getUntil();
+                $rangeEnd = $this->isInfinite() ? $rangeStart->copy()->addMonths(6) : $this->getUntil();
             }
 
             if ($this->getRRuleObject()) {


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-calendar/issues/349