### PR TITLE
fix(SFT-1661): exporting events when ICS description/location are not filled in

### DIFF
--- a/packages/plugin/src/Library/Export/ExportCalendarToIcs.php
+++ b/packages/plugin/src/Library/Export/ExportCalendarToIcs.php
@@ -68,13 +68,13 @@ class ExportCalendarToIcs extends AbstractExportCalendar
 
         $description = null;
         $descriptionFieldHandle = $event->getCalendar()->descriptionFieldHandle;
-        if (isset($event->{$descriptionFieldHandle})) {
+        if ($descriptionFieldHandle && isset($event->{$descriptionFieldHandle})) {
             $description = $event->{$descriptionFieldHandle};
         }
 
         $location = null;
         $locationFieldHandle = $event->getCalendar()->locationFieldHandle;
-        if (isset($event->{$locationFieldHandle})) {
+        if ($locationFieldHandle && isset($event->{$locationFieldHandle})) {
             $location = $event->{$locationFieldHandle};
         }
         $title = $event->title;


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-calendar/issues/350