### PR TITLE
fix(SFT-1775): events missing data after upgrading to Craft 5

### DIFF
--- a/packages/plugin/src/Console/Controllers/EventsController.php
+++ b/packages/plugin/src/Console/Controllers/EventsController.php
@@ -10,6 +10,7 @@ use craft\elements\db\ElementQueryInterface;
 use craft\events\BatchElementActionEvent;
 use craft\events\MultiElementActionEvent;
 use craft\services\Elements;
+use Solspace\Calendar\Console\Controllers\Fix\ContentFixMigration;
 use Solspace\Calendar\Console\Controllers\Fix\TitleFixMigration;
 use Solspace\Calendar\Elements\Db\EventQuery;
 use Solspace\Calendar\Elements\Event;
@@ -85,6 +86,18 @@ class EventsController extends Controller
         $migration->run();
 
         $this->stdout('Event titles fixed.'.\PHP_EOL, Console::FG_YELLOW);
+
+        return ExitCode::OK;
+    }
+
+    public function actionFixContents()
+    {
+        $this->stdout('Fixing event contents...'.\PHP_EOL, Console::FG_YELLOW);
+
+        $migration = new ContentFixMigration();
+        $migration->run();
+
+        $this->stdout('Event contents fixed.'.\PHP_EOL, Console::FG_YELLOW);
 
         return ExitCode::OK;
     }

--- a/packages/plugin/src/Console/Controllers/Fix/ContentFixMigration.php
+++ b/packages/plugin/src/Console/Controllers/Fix/ContentFixMigration.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Solspace\Calendar\Console\Controllers\Fix;
+
+use craft\db\Query;
+use craft\helpers\App;
+use craft\migrations\BaseContentRefactorMigration;
+use Solspace\Calendar\Elements\Event;
+
+class ContentFixMigration extends BaseContentRefactorMigration
+{
+    protected bool $preserveOldData = true;
+
+    public function run(): void
+    {
+        App::maxPowerCaptain();
+
+        $this->updateElements(
+            (new Query())->from(Event::tableName()),
+            \Craft::$app->getFields()->getLayoutByType(Event::class),
+        );
+    }
+}


### PR DESCRIPTION
Added new console command:
`php craft calendar/events/fix-contents`