### PR TITLE
fix(SFT-1875): ordering events, title must be of type string and site menu items in breadcrumbs

### DIFF
--- a/packages/plugin/src/Controllers/EventsController.php
+++ b/packages/plugin/src/Controllers/EventsController.php
@@ -178,7 +178,7 @@ class EventsController extends BaseController
             );
         }
 
-        return $this->renderEditForm($event, $event->title);
+        return $this->renderEditForm($event, $event->title ?? '');
     }
 
     /**
@@ -546,13 +546,19 @@ class EventsController extends BaseController
         $crumbs = [];
 
         if ($isCraft5 && $site && \Craft::$app->getIsMultiSite()) {
+            $allowedCalendarSites = Calendar::getInstance()->calendarSites->getAllowedCalendarSites($calendar);
+            $allowedCalendarSites = array_map(fn ($item) => $item['name'], $allowedCalendarSites);
+
+            $items = CpHelper::siteMenuItems($sites, $site);
+            $items = array_filter($items, fn ($item) => \in_array($item['label'], $allowedCalendarSites));
+
             $crumbs[] = [
                 'id' => 'site-crumb',
                 'icon' => Cp::earthIcon(),
                 'label' => \Craft::t('site', $site->name),
                 'menu' => [
                     'label' => \Craft::t('site', 'Select site'),
-                    'items' => CpHelper::siteMenuItems($sites, $site),
+                    'items' => $items,
                 ],
             ];
         }

--- a/packages/plugin/src/Elements/Db/EventQuery.php
+++ b/packages/plugin/src/Elements/Db/EventQuery.php
@@ -612,6 +612,8 @@ class EventQuery extends ElementQuery
             $eventsTable.'.[[authorId]]',
             $eventsTable.'.[[startDate]]',
             $eventsTable.'.[[endDate]]',
+            $eventsTable.'.[[dateCreated]]',
+            $eventsTable.'.[[dateUpdated]]',
             $eventsTable.'.[[allDay]]',
             $eventsTable.'.[[rrule]]',
             $eventsTable.'.[[freq]]',
@@ -657,6 +659,24 @@ class EventQuery extends ElementQuery
 
         if ($this->authorId) {
             $this->subQuery->andWhere(Db::parseParam($eventsTable.'.[[authorId]]', $this->authorId));
+        }
+
+        if ($this->dateCreated) {
+            $this->subQuery->andWhere(
+                Db::parseParam(
+                    $eventsTable.'.[[dateCreated]]',
+                    $this->extractDateAsFormattedString($this->dateCreated)
+                )
+            );
+        }
+
+        if ($this->dateUpdated) {
+            $this->subQuery->andWhere(
+                Db::parseParam(
+                    $eventsTable.'.[[dateUpdated]]',
+                    $this->extractDateAsFormattedString($this->dateUpdated)
+                )
+            );
         }
 
         if ($this->postDate) {
@@ -821,21 +841,6 @@ class EventQuery extends ElementQuery
 
             if (!PermissionHelper::isAdmin() && Calendar::getInstance()->settings->isAuthoredEventEditOnly()) {
                 $this->subQuery->andWhere($eventsTable.'.[[authorId]]', \Craft::$app->user->id);
-            }
-        }
-
-        if (\is_array($this->orderBy)) {
-            if (isset($this->orderBy['dateCreated'])) {
-                $sortDirection = $this->orderBy['dateCreated'];
-                $this->orderBy['[[calendar_events.dateCreated]]'] = $sortDirection;
-
-                unset($this->orderBy['dateCreated']);
-            }
-            if (isset($this->orderBy['postDate'])) {
-                $sortDirection = $this->orderBy['postDate'];
-                $this->orderBy['[[calendar_events.postDate]]'] = $sortDirection;
-
-                unset($this->orderBy['postDate']);
             }
         }
 

--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -1598,7 +1598,7 @@ class Event extends Element implements \JsonSerializable
     {
         $attributes = [
             'slug' => ['label' => Calendar::t('Slug')],
-            'calendar' => ['label' => Calendar::t('Calendar')],
+            'name' => ['label' => Calendar::t('Calendar')],
             'startDate' => ['label' => Calendar::t('Start Date')],
             'endDate' => ['label' => Calendar::t('End Date')],
             'dateCreated' => ['label' => Calendar::t('Date Created')],
@@ -1644,6 +1644,7 @@ class Event extends Element implements \JsonSerializable
     protected static function defineSearchableAttributes(): array
     {
         $attributes = [
+            'name',
             'authorId',
             'author',
             'id',
@@ -1666,7 +1667,7 @@ class Event extends Element implements \JsonSerializable
     protected static function defineDefaultTableAttributes(string $source): array
     {
         return [
-            'calendar',
+            'name',
             'startDate',
             'endDate',
             'dateCreated',

--- a/packages/plugin/src/Elements/Event.php
+++ b/packages/plugin/src/Elements/Event.php
@@ -1599,8 +1599,10 @@ class Event extends Element implements \JsonSerializable
         $attributes = [
             'slug' => ['label' => Calendar::t('Slug')],
             'calendar' => ['label' => Calendar::t('Calendar')],
-            'startDateLocalized' => ['label' => Calendar::t('Start Date')],
-            'endDateLocalized' => ['label' => Calendar::t('End Date')],
+            'startDate' => ['label' => Calendar::t('Start Date')],
+            'endDate' => ['label' => Calendar::t('End Date')],
+            'dateCreated' => ['label' => Calendar::t('Date Created')],
+            'dateUpdated' => ['label' => Calendar::t('Date Updated')],
             'allDay' => ['label' => Calendar::t('All Day')],
             'rrule' => ['label' => Calendar::t('Repeats')],
             'authorId' => ['label' => Calendar::t('Author ID')],
@@ -1625,6 +1627,8 @@ class Event extends Element implements \JsonSerializable
             'name' => Calendar::t('Calendar'),
             'startDate' => Calendar::t('Start Date'),
             'endDate' => Calendar::t('End Date'),
+            'dateCreated' => Calendar::t('Date Created'),
+            'dateUpdated' => Calendar::t('Date Updated'),
             'allDay' => Calendar::t('All Day'),
             'postDate' => Calendar::t('Post Date'),
         ];
@@ -1646,6 +1650,9 @@ class Event extends Element implements \JsonSerializable
             'title',
             'startDate',
             'endDate',
+            'dateCreated',
+            'dateUpdated',
+            'postDate',
         ];
 
         // Hide Author from Craft Solo
@@ -1662,6 +1669,8 @@ class Event extends Element implements \JsonSerializable
             'calendar',
             'startDate',
             'endDate',
+            'dateCreated',
+            'dateUpdated',
             'allDay',
             'postDate',
         ];

--- a/packages/plugin/src/Services/CalendarSitesService.php
+++ b/packages/plugin/src/Services/CalendarSitesService.php
@@ -4,9 +4,11 @@ namespace Solspace\Calendar\Services;
 
 use craft\base\Component;
 use craft\db\Query;
+use craft\records\Site;
 use Solspace\Calendar\Calendar;
 use Solspace\Calendar\Models\CalendarModel;
 use Solspace\Calendar\Models\CalendarSiteSettingsModel;
+use Solspace\Calendar\Records\CalendarRecord;
 use Solspace\Calendar\Records\CalendarSiteSettingsRecord;
 
 class CalendarSitesService extends Component
@@ -62,6 +64,19 @@ class CalendarSitesService extends Component
     {
         $path = Calendar::CONFIG_CALENDAR_SITES_PATH.'.'.$model->uid;
         \Craft::$app->projectConfig->remove($path);
+    }
+
+    public function getAllowedCalendarSites(CalendarModel $calendar): array
+    {
+        return (new Query())
+            ->select('*')
+            ->from(CalendarSiteSettingsRecord::TABLE.' calendarSites')
+            ->innerJoin(CalendarRecord::TABLE.' calendar', '[[calendar]].[[id]] = [[calendarSites]].[[calendarId]]')
+            ->innerJoin(Site::tableName().' sites', '[[calendarSites]].[[siteId]] = [[sites]].[[id]]')
+            ->where(['[[calendar]].[[id]]' => $calendar->id])
+            ->orderBy(['[[calendarSites]].[[id]]' => \SORT_ASC])
+            ->all()
+        ;
     }
 
     private function getQuery(): Query

--- a/packages/plugin/src/Services/EventsService.php
+++ b/packages/plugin/src/Services/EventsService.php
@@ -129,8 +129,8 @@ class EventsService extends Component
         $subQuery = (new Query());
         $subQuery->select($subQuerySelect);
         $subQuery->from(ElementRecord::tableName().' elements');
-        $subQuery->innerJoin(Event::tableName().' events', 'events.[[id]] = elements.[[id]]');
-        $subQuery->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = events.[[calendarId]]');
+        $subQuery->innerJoin(Event::tableName().' calendar_events', 'calendar_events.[[id]] = elements.[[id]]');
+        $subQuery->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = calendar_events.[[calendarId]]');
         $subQuery->innerJoin(ElementSiteSettingsRecord::tableName().' elements_sites', 'elements_sites.[[elementId]] = elements.[[id]]');
 
         if ($isCraft4) {
@@ -139,17 +139,21 @@ class EventsService extends Component
 
         $subQuery->where([
             'and',
-            'events.[[freq]] IS NULL',
+            'calendar_events.[[freq]] IS NULL',
             $whereDeleted,
-            ['in', 'events.[[id]]', $ids],
+            ['in', 'calendar_events.[[id]]', $ids],
             ['in', 'elements_sites.[[siteId]]', $siteIds],
         ]);
 
         $querySelect = [];
-        $querySelect[] = 'events.[[id]]';
-        $querySelect[] = 'events.[[startDate]]';
+        $querySelect[] = 'calendar_events.[[id]]';
+        $querySelect[] = 'calendar_events.[[postDate]]';
+        $querySelect[] = 'calendar_events.[[startDate]]';
+        $querySelect[] = 'calendar_events.[[endDate]]';
+        $querySelect[] = 'calendar_events.[[dateCreated]]';
+        $querySelect[] = 'calendar_events.[[dateUpdated]]';
         $querySelect[] = 'elements_sites.[[siteId]]';
-        $querySelect[] = 'events.[[id]]';
+        $querySelect[] = 'calendar_events.[[id]]';
 
         if ($isCraft4) {
             $querySelect[] = 'content.[[title]]';
@@ -162,8 +166,8 @@ class EventsService extends Component
         $query->from(['subQuery' => $subQuery]);
         $query->innerJoin(ElementRecord::tableName().' elements', 'elements.[[id]] = [[subQuery]].[[elementsId]]');
         $query->innerJoin(ElementSiteSettingsRecord::tableName().' elements_sites', 'elements_sites.[[id]] = [[subQuery]].[[elementsSitesId]]');
-        $query->innerJoin(Event::tableName().' events', 'events.[[id]] = [[subQuery]].[[elementsId]]');
-        $query->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = events.[[calendarId]]');
+        $query->innerJoin(Event::tableName().' calendar_events', 'calendar_events.[[id]] = [[subQuery]].[[elementsId]]');
+        $query->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = calendar_events.[[calendarId]]');
 
         if ($isCraft4) {
             $query->innerJoin(Table::CONTENT.' content', 'content.[[id]] = [[subQuery]].[[contentId]]');
@@ -195,8 +199,8 @@ class EventsService extends Component
         $subQuery = (new Query());
         $subQuery->select($subQuerySelect);
         $subQuery->from(ElementRecord::tableName().' elements');
-        $subQuery->innerJoin(Event::tableName().' events', 'events.[[id]] = elements.[[id]]');
-        $subQuery->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = events.[[calendarId]]');
+        $subQuery->innerJoin(Event::tableName().' calendar_events', 'calendar_events.[[id]] = elements.[[id]]');
+        $subQuery->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = calendar_events.[[calendarId]]');
         $subQuery->innerJoin(ElementSiteSettingsRecord::tableName().' elements_sites', 'elements_sites.[[elementId]] = elements.[[id]]');
 
         if ($isCraft4) {
@@ -205,25 +209,28 @@ class EventsService extends Component
 
         $subQuery->where([
             'and',
-            'events.[[freq]] IS NOT NULL',
+            'calendar_events.[[freq]] IS NOT NULL',
             $whereDeleted,
-            ['in', 'events.[[id]]', $ids],
+            ['in', 'calendar_events.[[id]]', $ids],
             ['in', 'elements_sites.[[siteId]]', $siteIds],
         ]);
 
         $querySelect = [];
-        $querySelect[] = 'events.[[id]]';
-        $querySelect[] = 'events.[[calendarId]]';
-        $querySelect[] = 'events.[[startDate]]';
-        $querySelect[] = 'events.[[endDate]]';
-        $querySelect[] = 'events.[[freq]]';
-        $querySelect[] = 'events.[[count]]';
-        $querySelect[] = 'events.[[interval]]';
-        $querySelect[] = 'events.[[byDay]]';
-        $querySelect[] = 'events.[[byMonthDay]]';
-        $querySelect[] = 'events.[[byMonth]]';
-        $querySelect[] = 'events.[[byYearDay]]';
-        $querySelect[] = 'events.[[until]]';
+        $querySelect[] = 'calendar_events.[[id]]';
+        $querySelect[] = 'calendar_events.[[calendarId]]';
+        $querySelect[] = 'calendar_events.[[postDate]]';
+        $querySelect[] = 'calendar_events.[[dateCreated]]';
+        $querySelect[] = 'calendar_events.[[dateUpdated]]';
+        $querySelect[] = 'calendar_events.[[startDate]]';
+        $querySelect[] = 'calendar_events.[[endDate]]';
+        $querySelect[] = 'calendar_events.[[freq]]';
+        $querySelect[] = 'calendar_events.[[count]]';
+        $querySelect[] = 'calendar_events.[[interval]]';
+        $querySelect[] = 'calendar_events.[[byDay]]';
+        $querySelect[] = 'calendar_events.[[byMonthDay]]';
+        $querySelect[] = 'calendar_events.[[byMonth]]';
+        $querySelect[] = 'calendar_events.[[byYearDay]]';
+        $querySelect[] = 'calendar_events.[[until]]';
         $querySelect[] = 'calendars.[[allowRepeatingEvents]]';
         $querySelect[] = 'elements_sites.[[siteId]]';
 
@@ -238,8 +245,8 @@ class EventsService extends Component
         $query->from(['subQuery' => $subQuery]);
         $query->innerJoin(ElementRecord::tableName().' elements', 'elements.[[id]] = [[subQuery]].[[elementsId]]');
         $query->innerJoin(ElementSiteSettingsRecord::tableName().' elements_sites', 'elements_sites.[[id]] = [[subQuery]].[[elementsSitesId]]');
-        $query->innerJoin(Event::tableName().' events', 'events.[[id]] = [[subQuery]].[[elementsId]]');
-        $query->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = events.[[calendarId]]');
+        $query->innerJoin(Event::tableName().' calendar_events', 'calendar_events.[[id]] = [[subQuery]].[[elementsId]]');
+        $query->innerJoin(CalendarRecord::tableName().' calendars', 'calendars.[[id]] = calendar_events.[[calendarId]]');
 
         if ($isCraft4) {
             $query->innerJoin(Table::CONTENT.' content', 'content.[[id]] = [[subQuery]].[[contentId]]');


### PR DESCRIPTION
Fixes

https://github.com/solspace/craft-calendar/issues/372
https://github.com/solspace/craft-calendar/issues/373

The main issue here was the `beforePrepare` did not use a table alias for the calendar event table so our column clause query was something like `calendar_events.[[id]]` but in our single and recurring event queries we were using "events" as our table alias resulting in a mismatch of columns like `calendar_events.[[id]], events.[[postDate]]` instead of `calendar_events.[[id]], calendar_events.[[postDate]]` etc. 