### PR TITLE
fix(SFT-2253): moved class references inside the conditionals and dynamically check for class existence before using them

### DIFF
--- a/packages/plugin/src/Bundles/Integrations/Plugins/Blitz/CalendarEventsBundle.php
+++ b/packages/plugin/src/Bundles/Integrations/Plugins/Blitz/CalendarEventsBundle.php
@@ -2,8 +2,6 @@
 
 namespace Solspace\Calendar\Bundles\Integrations\Plugins\Blitz;
 
-use putyourlightson\blitz\Blitz;
-use putyourlightson\blitz\drivers\purgers\DummyPurger;
 use Solspace\Calendar\Elements\Event as CalendarEvent;
 use Solspace\Calendar\Library\Bundles\BundleInterface;
 use yii\base\Event;
@@ -14,9 +12,19 @@ class CalendarEventsBundle implements BundleInterface
     public function __construct()
     {
         $plugins = \Craft::$app->getPlugins();
-        if ($plugins->isPluginInstalled('blitz') && $plugins->isPluginEnabled('blitz')) {
-            $purger = Blitz::$plugin->cachePurger;
-            if (!$purger instanceof DummyPurger) {
+
+        $blitzClass = 'putyourlightson\blitz\Blitz';
+        $dummyPurgerClass = 'putyourlightson\blitz\drivers\purgers\DummyPurger';
+
+        if (
+            $plugins->isPluginInstalled('blitz')
+            && $plugins->isPluginEnabled('blitz')
+            && class_exists($blitzClass)
+            && class_exists($dummyPurgerClass)
+        ) {
+            $purger = $blitzClass::$plugin->cachePurger;
+
+            if (!$purger instanceof $dummyPurgerClass) {
                 Event::on(
                     CalendarEvent::class,
                     CalendarEvent::EVENT_AFTER_SAVE,

--- a/packages/plugin/src/Bundles/Integrations/Plugins/Freeform/CalendarEventsBundle.php
+++ b/packages/plugin/src/Bundles/Integrations/Plugins/Freeform/CalendarEventsBundle.php
@@ -4,8 +4,6 @@ namespace Solspace\Calendar\Bundles\Integrations\Plugins\Freeform;
 
 use Solspace\Calendar\Integrations\Plugins\Freeform\CalendarEvents\CalendarEvents;
 use Solspace\Calendar\Library\Bundles\BundleInterface;
-use Solspace\Freeform\Events\Integrations\RegisterIntegrationTypesEvent;
-use Solspace\Freeform\Services\Integrations\IntegrationsService;
 use yii\base\Event;
 
 class CalendarEventsBundle implements BundleInterface
@@ -14,11 +12,22 @@ class CalendarEventsBundle implements BundleInterface
     {
         $plugins = \Craft::$app->getPlugins();
         $freeform = $plugins->getStoredPluginInfo('freeform');
-        if ($plugins->isPluginInstalled('freeform') && $plugins->isPluginEnabled('freeform') && $freeform && $freeform['version'] >= '5.0.0') {
+
+        $integrationsServiceClass = 'Solspace\Freeform\Services\Integrations\IntegrationsService';
+        $registerIntegrationTypesEventClass = 'Solspace\Freeform\Events\Integrations\RegisterIntegrationTypesEvent';
+
+        if (
+            $plugins->isPluginInstalled('freeform')
+            && $plugins->isPluginEnabled('freeform')
+            && class_exists($integrationsServiceClass)
+            && class_exists($registerIntegrationTypesEventClass)
+            && $freeform
+            && $freeform['version'] >= '5.0.0'
+        ) {
             Event::on(
-                IntegrationsService::class,
-                IntegrationsService::EVENT_REGISTER_INTEGRATION_TYPES,
-                function (RegisterIntegrationTypesEvent $event) {
+                $integrationsServiceClass,
+                \constant("{$integrationsServiceClass}::EVENT_REGISTER_INTEGRATION_TYPES"),
+                function ($event) {
                     $event->addType(CalendarEvents::class);
                 }
             );


### PR DESCRIPTION
PHP CS Fixer–safe version