### PR TITLE
fix(SFT-2328): GraphQL field resolver on calendars

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "solspace/craft-calendar",
   "description": "The most powerful event management and calendaring plugin!",
-  "version": "5.0.24",
+  "version": "5.0.24.1",
   "type": "craft-plugin",
   "authors": [
     {

--- a/packages/plugin/src/Bundles/GraphQL/Resolvers/CalendarResolver.php
+++ b/packages/plugin/src/Bundles/GraphQL/Resolvers/CalendarResolver.php
@@ -2,15 +2,39 @@
 
 namespace Solspace\Calendar\Bundles\GraphQL\Resolvers;
 
+use craft\elements\Entry;
 use craft\gql\base\Resolver;
 use GraphQL\Type\Definition\ResolveInfo;
 use Solspace\Calendar\Bundles\GraphQL\GqlPermissions;
 use Solspace\Calendar\Calendar;
+use Solspace\Calendar\Models\CalendarModel;
 
 class CalendarResolver extends Resolver
 {
     public static function resolve(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): array
     {
+        // If this field is being resolved on an Entry, use the entry's actual field value.
+        if ($source instanceof Entry) {
+            $value = $source->getFieldValue($resolveInfo->fieldName);
+
+            if (empty($value)) {
+                return [];
+            }
+
+            $calendars = Calendar::getInstance()->calendars;
+
+            return array_values(array_filter(array_map(function ($item) use ($calendars) {
+                if ($item instanceof CalendarModel) {
+                    return $item;
+                }
+
+                $id = \is_array($item) && isset($item['id']) ? (int) $item['id'] : (int) $item;
+
+                return $id ? $calendars->getCalendarById($id) : null;
+            }, (array) $value)));
+        }
+
+        // Original behavior for top-level calendar queries
         $arguments = self::getArguments($arguments);
 
         return Calendar::getInstance()->calendars->getResolvedCalendars($arguments);
@@ -18,6 +42,32 @@ class CalendarResolver extends Resolver
 
     public static function resolveOne($source, array $arguments, $context, ResolveInfo $resolveInfo)
     {
+        // If this field is being resolved on an Entry, use the entry's actual field value.
+        if ($source instanceof Entry) {
+            $value = $source->getFieldValue($resolveInfo->fieldName);
+
+            // Normalize a few possible shapes to a single CalendarModel (or null)
+            if ($value instanceof CalendarModel) {
+                return $value;
+            }
+
+            if (\is_array($value) && !empty($value)) {
+                $first = reset($value);
+
+                if ($first instanceof CalendarModel) {
+                    return $first;
+                }
+
+                // If stored as ids, load the first one
+                $id = \is_array($first) && isset($first['id']) ? (int) $first['id'] : (int) $first;
+
+                return Calendar::getInstance()->calendars->getCalendarById($id);
+            }
+
+            return null;
+        }
+
+        // Fallback for top-level queries where there's no Entry $source
         $arguments = self::getArguments($arguments);
         $arguments['limit'] = 1;
 

--- a/packages/plugin/src/Integrations/Plugins/Freeform/CalendarEvents/CalendarOptionsGenerator.php
+++ b/packages/plugin/src/Integrations/Plugins/Freeform/CalendarEvents/CalendarOptionsGenerator.php
@@ -3,6 +3,7 @@
 namespace Solspace\Calendar\Integrations\Plugins\Freeform\CalendarEvents;
 
 use Solspace\Calendar\Calendar;
+use Solspace\Freeform\Attributes\Property\Implementations\Options\Option;
 use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollection;
 use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionsGeneratorInterface;
 use Solspace\Freeform\Attributes\Property\Property;
@@ -13,11 +14,16 @@ class CalendarOptionsGenerator implements OptionsGeneratorInterface
     {
         $options = new OptionCollection();
 
-        $calendar = Calendar::getInstance();
-        if ($calendar) {
-            $calendars = $calendar->calendars->getCalendars();
+        $calendarPlugin = Calendar::getInstance();
+        if ($calendarPlugin) {
+            $calendars = $calendarPlugin->calendars->getCalendars();
             foreach ($calendars as $calendar) {
-                $options->add($calendar->id, $calendar->name);
+                $options->add(
+                    new Option(
+                        value: (string) $calendar->id,
+                        label: $calendar->name
+                    )
+                );
             }
         }
 


### PR DESCRIPTION
```
query MyQuery {
  entries(section: "myTestSingle", site: "craft5English", status: "live", orderBy: "postDate DESC") {
    id
    title
    slug
    uri
    url
    dateCreated @formatDateTime(format: "Y-m-d H:i")
    ... on myEntryType_Entry {
      id
      calendarCalendars {
        id
        handle
        name
        color
      }
    }
  }
}
```

```
{
  "data": {
    "entries": [
      {
        "id": "13",
        "title": "My Test Single",
        "slug": "my-test-single",
        "uri": null,
        "url": null,
        "dateCreated": "2025-08-08 03:50",
        "calendarCalendars": {
          "id": 2,
          "handle": "mySecondCalendar",
          "name": "My Second Calendar",
          "color": "#BDE94C"
        }
      }
    ]
  }
}
```

<img width="655" height="358" alt="image" src="https://github.com/user-attachments/assets/142df3a8-f220-45f1-9ba0-341592f51331" />
