### PR TITLE
fix(SFT-2760): allow null in EventQuery::setAllDay() to prevent TypeError

### DIFF
--- a/packages/plugin/src/Elements/Db/EventQuery.php
+++ b/packages/plugin/src/Elements/Db/EventQuery.php
@@ -87,7 +87,8 @@ class EventQuery extends ElementQuery
     private \DateTime|string|null $rangeEnd = null;
     private array|string|null $timezone = null;
 
-    private bool $allDay = false;
+    private ?bool $allDay = null;
+
     private bool $allowedCalendarsOnly = false;
 
     private ?int $overlapThreshold = null;
@@ -268,7 +269,7 @@ class EventQuery extends ElementQuery
         return $this;
     }
 
-    public function setAllDay(bool $value): self
+    public function setAllDay(?bool $value): self
     {
         $this->allDay = $value;
 


### PR DESCRIPTION
Related to https://github.com/solspace/craft-calendar/pull/446

Fixes: https://github.com/solspace/craft-calendar/issues/436